### PR TITLE
Fix zephyr module

### DIFF
--- a/03-twister/example-application/west.yml
+++ b/03-twister/example-application/west.yml
@@ -10,7 +10,7 @@ manifest:
   projects:
     - name: zephyr
       remote: zephyrproject-rtos
-      revision: main
+      revision: 916df03e7aeceb9164c62a326e81a86d74742bb7
       import:
         # By using name-allowlist we can clone only the modules that are
         # strictly needed by the application.


### PR DESCRIPTION
When I was running the example, I got this error:

```
west twister --platform stm32f7 -T hello_world
INFO    - Using Ninja..
INFO    - Zephyr version: v3.5.0-rc2-76-g916df03e7aec
INFO    - Using 'zephyr' toolchain.
ERROR   - platform_filter - unrecognized platform - stm32f7
```

This is because of the missing `zephyr/module.yml`. Probably it was not pushed, because it was ignored by `03-twister/.gitignore`